### PR TITLE
Fixes issue when there is no default configuration

### DIFF
--- a/AleRoe.LiteDB.Extensions.DependencyInjection.Tests/LiteDatabaseServiceExtensionsTests.cs
+++ b/AleRoe.LiteDB.Extensions.DependencyInjection.Tests/LiteDatabaseServiceExtensionsTests.cs
@@ -17,8 +17,8 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
         public void AddLiteDatabaseTest_Default()
         {
             using (var provider = new ServiceCollection()
-                .AddLiteDatabase()
                 .AddSingleton<IConfiguration>(Configuration)
+                .AddLiteDatabase()
                 .BuildServiceProvider())
             {
                 Assert.DoesNotThrow(() => provider.GetRequiredService<LiteDatabase>());
@@ -29,8 +29,8 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
         public void AddLiteDatabaseTest_Default_MissingConnectionStringThrows()
         {
             using (var provider = new ServiceCollection()
-                .AddLiteDatabase()
                 .AddSingleton<IConfiguration>(EmptyConfiguration)
+                .AddLiteDatabase()
                 .BuildServiceProvider())
             {
                 Assert.Throws<ArgumentNullException>(() => provider.GetRequiredService<LiteDatabase>());
@@ -116,12 +116,11 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
         }
 
         [Test()]
-        public void AddLiteDatabaseTest_WithPostConfigure()
+        public void AddLiteDatabaseTest_WithConfigureOption()
         {
             using (var provider = new ServiceCollection()
-                .AddLiteDatabase()
                 .AddSingleton<IConfiguration>(Configuration)
-                .ConfigureOptions<ConfigureLiteDatabaseServiceOptions>()
+                .AddLiteDatabase<ConfigureLiteDatabaseServiceOptionsConnString>()
                 .BuildServiceProvider())
             {
                 LiteDatabase database = null;
@@ -131,26 +130,11 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
         }
 
         [Test()]
-        public void AddLiteDatabaseTest_WithPostConfigure_ConnectionString()
+        public void AddLiteDatabaseTest_WithConfigureOption_EmptyConfiguration()
         {
             using (var provider = new ServiceCollection()
-                .AddLiteDatabase()
-                .AddSingleton<IConfiguration>(Configuration)
-                .ConfigureOptions<ConfigureLiteDatabaseServiceOptionsConnString>()
-                .BuildServiceProvider())
-            {
-                LiteDatabase database = null;
-                Assert.DoesNotThrow(() => database = provider.GetRequiredService<LiteDatabase>());
-                Assert.IsFalse(database.Mapper.EmptyStringToNull);
-            }
-        }
-        [Test()]
-        public void AddLiteDatabaseTest_WithPostConfigure_EmptyConfiguration()
-        {
-            using (var provider = new ServiceCollection()
-                .AddLiteDatabase()
                 .AddSingleton<IConfiguration>(EmptyConfiguration)
-                .ConfigureOptions<ConfigureLiteDatabaseServiceOptionsConnString>()
+                .AddLiteDatabase<ConfigureLiteDatabaseServiceOptionsConnString>()
                 .BuildServiceProvider())
             {
                 LiteDatabase database = null;

--- a/AleRoe.LiteDB.Extensions.DependencyInjection.Tests/LiteDatabaseServiceExtensionsTests.cs
+++ b/AleRoe.LiteDB.Extensions.DependencyInjection.Tests/LiteDatabaseServiceExtensionsTests.cs
@@ -48,11 +48,35 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
                 Assert.DoesNotThrow(() => provider.GetRequiredService<LiteDatabase>());
             }
         }
+        [Test()]
+        public void AddLiteDatabaseTest_WithOptions_EmptyConfiguration()
+        {
+            var options = new LiteDatabaseServiceOptions(ConnectionString);
+            using (var provider = new ServiceCollection()
+                .AddSingleton<IConfiguration>(EmptyConfiguration)
+                .AddLiteDatabase(options)
+                .BuildServiceProvider())
+            {
+                Assert.DoesNotThrow(() => provider.GetRequiredService<LiteDatabase>());
+            }
+        }
 
         [Test()]
         public void AddLiteDatabaseTest_WithConnectionString()
         {
             using (var provider = new ServiceCollection()
+                .AddLiteDatabase(ConnectionString)
+                .BuildServiceProvider())
+            {
+                Assert.DoesNotThrow(() => provider.GetRequiredService<LiteDatabase>());
+            }
+        }
+
+        [Test()]
+        public void AddLiteDatabaseTest_WithConnectionString_EmptyConfiguration()
+        {
+            using (var provider = new ServiceCollection()
+                .AddSingleton<IConfiguration>(EmptyConfiguration)
                 .AddLiteDatabase(ConnectionString)
                 .BuildServiceProvider())
             {
@@ -75,6 +99,21 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
                 Assert.DoesNotThrow(() => provider.GetRequiredService<LiteDatabase>());
             }
         }
+        [Test()]
+        public void AddLiteDatabaseTest_WithConfigure_EmptyConfiguration()
+        {
+            using (var provider = new ServiceCollection()
+                .AddSingleton<IConfiguration>(EmptyConfiguration)
+                .AddLiteDatabase(configure =>
+                {
+                    configure.ConnectionString.Filename = ConnectionString;
+                    configure.Mapper.EmptyStringToNull = false;
+                })
+                .BuildServiceProvider())
+            {
+                Assert.DoesNotThrow(() => provider.GetRequiredService<LiteDatabase>());
+            }
+        }
 
         [Test()]
         public void AddLiteDatabaseTest_WithPostConfigure()
@@ -83,6 +122,35 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
                 .AddLiteDatabase()
                 .AddSingleton<IConfiguration>(Configuration)
                 .ConfigureOptions<ConfigureLiteDatabaseServiceOptions>()
+                .BuildServiceProvider())
+            {
+                LiteDatabase database = null;
+                Assert.DoesNotThrow(() => database = provider.GetRequiredService<LiteDatabase>());
+                Assert.IsFalse(database.Mapper.EmptyStringToNull);
+            }
+        }
+
+        [Test()]
+        public void AddLiteDatabaseTest_WithPostConfigure_ConnectionString()
+        {
+            using (var provider = new ServiceCollection()
+                .AddLiteDatabase()
+                .AddSingleton<IConfiguration>(Configuration)
+                .ConfigureOptions<ConfigureLiteDatabaseServiceOptionsConnString>()
+                .BuildServiceProvider())
+            {
+                LiteDatabase database = null;
+                Assert.DoesNotThrow(() => database = provider.GetRequiredService<LiteDatabase>());
+                Assert.IsFalse(database.Mapper.EmptyStringToNull);
+            }
+        }
+        [Test()]
+        public void AddLiteDatabaseTest_WithPostConfigure_EmptyConfiguration()
+        {
+            using (var provider = new ServiceCollection()
+                .AddLiteDatabase()
+                .AddSingleton<IConfiguration>(EmptyConfiguration)
+                .ConfigureOptions<ConfigureLiteDatabaseServiceOptionsConnString>()
                 .BuildServiceProvider())
             {
                 LiteDatabase database = null;
@@ -111,6 +179,14 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
         {
             public void Configure(LiteDatabaseServiceOptions options)
             {
+                options.Mapper.EmptyStringToNull = false;
+            }
+        }
+        internal class ConfigureLiteDatabaseServiceOptionsConnString : IConfigureOptions<LiteDatabaseServiceOptions>
+        {
+            public void Configure(LiteDatabaseServiceOptions options)
+            {
+                options.ConnectionString = new ConnectionString(":memory:");
                 options.Mapper.EmptyStringToNull = false;
             }
         }

--- a/AleRoe.LiteDB.Extensions.DependencyInjection.Tests/LiteDatabaseServiceExtensionsTests.cs
+++ b/AleRoe.LiteDB.Extensions.DependencyInjection.Tests/LiteDatabaseServiceExtensionsTests.cs
@@ -116,6 +116,50 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection.Tests
         }
 
         [Test()]
+        public void AddLiteDatabaseTest_WithPostConfigure()
+        {
+            using (var provider = new ServiceCollection()
+                .AddSingleton<IConfiguration>(Configuration)
+                .AddLiteDatabase()
+                .ConfigureOptions<ConfigureLiteDatabaseServiceOptionsConnString>()
+                .BuildServiceProvider())
+            {
+                LiteDatabase database = null;
+                Assert.DoesNotThrow(() => database = provider.GetRequiredService<LiteDatabase>());
+                Assert.IsFalse(database.Mapper.EmptyStringToNull);
+            }
+        }
+
+        [Test()]
+        public void AddLiteDatabaseTest_WithPostConfigure_ConnectionString()
+        {
+            using (var provider = new ServiceCollection()
+                .AddSingleton<IConfiguration>(Configuration)
+                .AddLiteDatabase()
+                .ConfigureOptions<ConfigureLiteDatabaseServiceOptionsConnString>()
+                .BuildServiceProvider())
+            {
+                LiteDatabase database = null;
+                Assert.DoesNotThrow(() => database = provider.GetRequiredService<LiteDatabase>());
+                Assert.IsFalse(database.Mapper.EmptyStringToNull);
+            }
+        }
+
+        [Test()]
+        public void AddLiteDatabaseTest_WithPostConfigure_ConnectionString_EmptyConfiguration()
+        {
+            using (var provider = new ServiceCollection()
+                .AddSingleton<IConfiguration>(EmptyConfiguration)
+                .AddLiteDatabase()
+                .ConfigureOptions<ConfigureLiteDatabaseServiceOptionsConnString>()
+                .BuildServiceProvider())
+            {
+                LiteDatabase database = null;
+                Assert.Throws<ArgumentNullException>(() => database = provider.GetRequiredService<LiteDatabase>());
+            }
+        }
+
+        [Test()]
         public void AddLiteDatabaseTest_WithConfigureOption()
         {
             using (var provider = new ServiceCollection()

--- a/AleRoe.LiteDB.Extensions.DependencyInjection/LiteDatabaseServiceExtensions.cs
+++ b/AleRoe.LiteDB.Extensions.DependencyInjection/LiteDatabaseServiceExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace AleRoe.LiteDB.Extensions.DependencyInjection
 {
@@ -95,6 +96,15 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection
             });
         }
 
+        public static IServiceCollection AddLiteDatabase<T>(this IServiceCollection services) where T : IConfigureOptions<LiteDatabaseServiceOptions>
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+
+            return services
+                .AddLiteDbCore()
+                .ConfigureOptions(typeof(T));
+        }
+
         /// <summary>
         /// Adds the core services for LiteDatabase.
         /// </summary>
@@ -105,19 +115,6 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection
             if (services == null) throw new ArgumentNullException(nameof(services));
 
             services.AddOptions();
-            services.AddOptions<LiteDatabaseServiceOptions>()
-                .Configure<IServiceProvider>((options, provider) =>
-                {
-                    var factory = provider.GetService<ILoggerFactory>();
-                    options.Logger = factory?.CreateLogger(LiteDatabaseLoggerCategory);
-
-                    var configuration = provider.GetService<IConfiguration>();
-                    if (configuration != null)
-                    {
-                        var connectionString = configuration.GetConnectionString(LiteDatabaseConnectionStringKey);
-                        options.ConnectionString = new ConnectionString(connectionString);
-                    }
-                });
             services.TryAddTransient<ILiteDatabaseFactory, LiteDatabaseFactory>();
             services.TryAddSingleton<LiteDatabase>(provider =>
             {

--- a/AleRoe.LiteDB.Extensions.DependencyInjection/LiteDatabaseServiceExtensions.cs
+++ b/AleRoe.LiteDB.Extensions.DependencyInjection/LiteDatabaseServiceExtensions.cs
@@ -115,6 +115,12 @@ namespace AleRoe.LiteDB.Extensions.DependencyInjection
             if (services == null) throw new ArgumentNullException(nameof(services));
 
             services.AddOptions();
+            services.AddOptions<LiteDatabaseServiceOptions>()
+                .Configure<IServiceProvider>((options, provider) =>
+                {
+                    var factory = provider.GetService<ILoggerFactory>();
+                    options.Logger = factory?.CreateLogger(LiteDatabaseLoggerCategory);
+                });
             services.TryAddTransient<ILiteDatabaseFactory, LiteDatabaseFactory>();
             services.TryAddSingleton<LiteDatabase>(provider =>
             {


### PR DESCRIPTION
Hello author, 
I wanted to test LiteDb today and for the first time and used your library to add it to my project. I had a hard time haha, but I learned. 

I tried first to use the option class option to configure it LiteDb. It was crashing with a null exception due to the connection string and I could not figure out why. I then tried by specifying the an Action<LiteDatabaseServiceOptions> with a connectionString, but the result was the same. 

I found that the AddLiteDbCore, used in all the configuration, will always try to read from the configuration file and locate the connectionstring { litedb... } key. In myproject, I did not have this key nor the ConnectionString section. This is what was causing the exception. 
Since all your method that use AddLiteDbCore provide/register the option right after, I don't think it the configureation should be added in the AddLiteDbCore. It should only be added to the default parameterless extension, that reads from it. 
At first I just removed the code from AddLiteDbCore, but the logs stopped working. 
I am no expert with IOption, but they seems to stack ?? Do they stack? It seems that registering them multiple times will still work. If that's the case then it could be ok, but please do verify if you can register the login, then register the rest of the options, in two different register call, and if they stack. Otherwise you will need to move your logger registration in a different place. 

There was also some issue with the post configure. 
If you want to use an option class, it's weird to use the configure action, or other extensions. You end up with using the default parameterless constructor, which expect the connection string in the IConfiguration. Since it's not there, it will crash. 
I added a new extension to take care of a problem with the post configure. The new extension add litedb and register the option class in one go. There is also no guessing if another option will be added later. The post configure might not be a so good idea. Note that I have added a test that throw for the above case just to show why it's needed. 

It's kinda late and I'm tired, I hope I was good enough to explain the issue and the changes that I made. 

